### PR TITLE
Created IPathway interface and changed users of Pathway to use IPathway instead

### DIFF
--- a/Behaviors/SteerForPathSimplified.cs
+++ b/Behaviors/SteerForPathSimplified.cs
@@ -52,7 +52,7 @@ public class SteerForPathSimplified : Steering
 	/// <summary>
 	/// Path to follow
 	/// </summary>
-	public Pathway Path { get; set; }
+	public IPathway Path { get; set; }
 	#endregion
 
 	/// <summary>

--- a/IPathway.cs
+++ b/IPathway.cs
@@ -1,0 +1,33 @@
+using UnityEngine;
+
+namespace UnitySteer
+{
+	public interface IPathway
+	{
+		bool IsCyclic { get; }
+		float TotalPathLength { get; }
+		Vector3 FirstPoint { get; }
+		Vector3 LastPoint { get; }
+		int SegmentCount { get; }
+
+		// Given an arbitrary point ("A"), returns the nearest point ("P") on
+		// this path.  Also returns, via output arguments, the path tangent at
+		// P and a measure of how far A is outside the Pathway's "tube".  Note
+		// that a negative distance indicates A is inside the Pathway.
+		Vector3 MapPointToPath (Vector3 point, ref PathRelativePosition tStruct);
+
+		// given a distance along the path, convert it to a point on the path
+		Vector3 MapPathDistanceToPoint (float pathDistance);
+
+		// Given an arbitrary point, convert it to a distance along the path.
+		float MapPointToPathDistance (Vector3 point);
+
+		// is the given point inside the path tube?
+		bool IsInsidePath (Vector3 point);
+
+		// how far outside path tube is the given point?  (negative is inside)
+		float HowFarOutsidePath (Vector3 point);
+
+		void DrawGizmos ();
+	}
+}

--- a/PathWay.cs
+++ b/PathWay.cs
@@ -46,7 +46,7 @@ namespace UnitySteer
 		public int segmentIndex;
 	}
 
-    public abstract class Pathway
+    public abstract class Pathway : IPathway
     {
         private bool _isCyclic;
         

--- a/UnderReview/SteerLibrary.cs
+++ b/UnderReview/SteerLibrary.cs
@@ -108,7 +108,7 @@ namespace UnitySteer
 		// ----------------------------------------------------------------------------
 		// Path Following behaviors
 
-		public Vector3 steerToStayOnPath(float predictionTime, Pathway path)
+		public Vector3 steerToStayOnPath(float predictionTime, IPathway path)
 		{
 			// predict our future position
 			Vector3 futurePosition = predictFuturePosition (predictionTime);

--- a/UnderReview/SteerToFollowPath.cs
+++ b/UnderReview/SteerToFollowPath.cs
@@ -29,7 +29,7 @@ public class SteerToFollowPath : Steering
 	#region Private fields
 	FollowDirection _direction = FollowDirection.Forward;
 	float _predictionTime = 2f;
-	Pathway _path;
+	IPathway _path;
 	#endregion
 	
 	
@@ -61,7 +61,7 @@ public class SteerToFollowPath : Steering
 	/// <summary>
 	/// Path to follow
 	/// </summary>
-	public Pathway Path {
+	public IPathway Path {
 		get {
 			return this._path;
 		}


### PR DESCRIPTION
Previously, all pathway code was based on the abstract class "Pathway." Because it is an abstract class, rather than an interface, it made it difficult for objects that already derive from another class (e.g. MonoBehaviour) to provide pathway information.

Switching to an interface allows those classes to implement the required methods without losing their existing base class relationship; and because the Pathway class itself supports the interface, no existing code should be affected.
