### PR TITLE
Custom Forward/Up vectors, specify allowed rotation axes

### DIFF
--- a/Behaviors/AutonomousVehicle.cs
+++ b/Behaviors/AutonomousVehicle.cs
@@ -48,7 +48,7 @@ namespace UnitySteer.Behaviors
         /// </summary>
         public override Vector3 Velocity
         {
-            get { return Transform.forward * Speed; }
+            get { return Forward * Speed; }
             protected set { throw new NotSupportedException("Cannot set the velocity directly on AutonomousVehicle"); }
         }
 
@@ -62,7 +62,7 @@ namespace UnitySteer.Behaviors
         protected override void SetCalculatedVelocity(Vector3 velocity)
         {
             TargetSpeed = velocity.magnitude;
-            OrientationVelocity = Mathf.Approximately(_speed, 0) ? Transform.forward : velocity / TargetSpeed;
+            OrientationVelocity = Mathf.Approximately(_speed, 0) ? Forward : velocity / TargetSpeed;
         }
 
         /// <summary>

--- a/Behaviors/DetectableObject.cs
+++ b/Behaviors/DetectableObject.cs
@@ -23,6 +23,15 @@ namespace UnitySteer.Behaviors
         /// </summary>
         [SerializeField] private float _radius = 1;
 
+        /// <summary>
+        /// Custom forward vector, allows custom orientation of objects. Default Vector3.forward
+        /// </summary>
+        [SerializeField] private Vector3 _forwardVector = Vector3.forward;
+
+        /// <summary>
+        /// Custom up vector, allows custom orientation of objects. Default Vector3.up
+        /// </summary>
+        [SerializeField] private Vector3 _upVector = Vector3.up;
 
         /// <summary>
         /// Collider attached to this object. The GameObject that the DetectableObject
@@ -92,6 +101,30 @@ namespace UnitySteer.Behaviors
             }
         }
 
+        /// <summary>
+        /// Custom forward vector, allows custom orientation of objects. Default Vector3.forward
+        /// </summary>
+		public Vector3 ForwardVector
+        {
+            get { return _forwardVector; }
+        }
+
+		/// <summary>
+        /// Custom up vector, allows custom orientation of objects. Default Vector3.up
+        /// </summary>
+        public Vector3 UpVector
+        {
+            get { return _upVector; }
+        }
+		
+        /// <summary>
+        /// ForwardVector rotated by Transform current rotation
+        /// </summary>
+		public Vector3 Forward
+        {
+            get { return Transform.rotation * ForwardVector; }
+        }
+		
         #region Methods
 
         protected virtual void Awake()
@@ -152,5 +185,6 @@ namespace UnitySteer.Behaviors
         }
 
         #endregion
+
     }
 }

--- a/Behaviors/PassiveVehicle.cs
+++ b/Behaviors/PassiveVehicle.cs
@@ -48,7 +48,7 @@ namespace UnitySteer.Behaviors
         /// </summary>
         public override Vector3 Velocity
         {
-            get { return Transform.forward * _speed; }
+            get { return Forward * _speed; }
             protected set { throw new NotSupportedException("Cannot set the velocity directly on PassiveCehicle"); }
         }
 

--- a/Behaviors/SteerForAlignment.cs
+++ b/Behaviors/SteerForAlignment.cs
@@ -13,7 +13,7 @@ namespace UnitySteer.Behaviors
         public override Vector3 CalculateNeighborContribution(Vehicle other)
         {
             // accumulate sum of neighbor's heading
-            return other.Transform.forward;
+            return other.Forward;
         }
     }
 }

--- a/Behaviors/SteerForForward.cs
+++ b/Behaviors/SteerForForward.cs
@@ -17,7 +17,7 @@ namespace UnitySteer.Behaviors
         /// </summary>
         public Vector3 DesiredForward
         {
-            get { return _overrideForward ? _desiredForward : Vehicle.Transform.forward; }
+            get { return _overrideForward ? _desiredForward : Vehicle.Forward; }
             set
             {
                 _desiredForward = value;
@@ -33,7 +33,7 @@ namespace UnitySteer.Behaviors
         /// </returns>
         protected override Vector3 CalculateForce()
         {
-            return _overrideForward ? DesiredForward : Vehicle.Transform.forward;
+            return _overrideForward ? DesiredForward : Vehicle.Forward;
         }
     }
 }

--- a/Behaviors/SteerForMinimumSpeed.cs
+++ b/Behaviors/SteerForMinimumSpeed.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 
 namespace UnitySteer.Behaviors
 {
@@ -40,7 +40,7 @@ namespace UnitySteer.Behaviors
             var result = Vehicle.DesiredVelocity;
             if (_moveForwardWhenZero && Mathf.Approximately(Vehicle.TargetSpeed, 0))
             {
-                result = Vehicle.Transform.forward * _minimumSpeed;
+                result = Vehicle.Forward * _minimumSpeed;
             }
             else if (Vehicle.TargetSpeed < _minimumSpeed)
             {

--- a/Behaviors/SteerForPursuit.cs
+++ b/Behaviors/SteerForPursuit.cs
@@ -87,11 +87,11 @@ namespace UnitySteer.Behaviors
 
             // how parallel are the paths of "this" and the quarry
             // (1 means parallel, 0 is pependicular, -1 is anti-parallel)
-            var parallelness = Vector3.Dot(transform.forward, _quarry.transform.forward);
+            var parallelness = Vector3.Dot(Vehicle.Forward, _quarry.Forward);
 
             // how "forward" is the direction to the quarry
             // (1 means dead ahead, 0 is directly to the side, -1 is straight back)
-            var forwardness = Vector3.Dot(transform.forward, unitOffset);
+            var forwardness = Vector3.Dot(Vehicle.Forward, unitOffset);
 
             var directTravelTime = distance / Vehicle.Speed;
             // While we could parametrize this value, if we care about forward/backwards

--- a/Behaviors/TickedVehicle.cs
+++ b/Behaviors/TickedVehicle.cs
@@ -274,12 +274,15 @@ namespace UnitySteer.Behaviors
             if (TargetSpeed > MinSpeedForTurning && Velocity != Vector3.zero)
             {
                 var newForward = Vector3.Scale(OrientationVelocity, AllowedMovementAxes).normalized;
+                Quaternion rot = Quaternion.LookRotation( newForward, UpVector);
+                rot = new Quaternion( rot.x * AllowedRotationAxes.x, 
+                    rot.y * AllowedRotationAxes.y, rot.z * AllowedRotationAxes.z, rot.w);
                 if (TurnTime > 0)
                 {
-                    newForward = Vector3.Slerp(Transform.forward, newForward, deltaTime / TurnTime);
+                    rot = Quaternion.Slerp(Transform.rotation, rot, deltaTime / TurnTime);
                 }
 
-                Transform.forward = newForward;
+                Transform.rotation = rot;
             }
         }
 

--- a/Behaviors/Vehicle.cs
+++ b/Behaviors/Vehicle.cs
@@ -59,6 +59,16 @@ namespace UnitySteer.Behaviors
         /// </remarks>
         [SerializeField, Vector3Toggle] private Vector3 _allowedMovementAxes = Vector3.one;
 
+		/// <summary>
+        /// Indicates which axes a vehicle is allowed to rotate around
+        /// </summary>
+        /// <remarks>
+        /// A 0 on the X/Y/Z value means the vehicle is not allowed to rotate on that
+        /// axis, a 1 indicates it can.  We use Vector3Toggle to set it on the 
+        /// editor as a helper.
+        /// </remarks>
+        [SerializeField, Vector3Toggle] private Vector3 _allowedRotationAxes = Vector3.one;
+
         /// <summary>
         /// The vehicle's arrival radius.
         /// </summary>
@@ -85,6 +95,11 @@ namespace UnitySteer.Behaviors
         public Vector3 AllowedMovementAxes
         {
             get { return _allowedMovementAxes; }
+        }
+
+        public Vector3 AllowedRotationAxes
+        {
+            get { return _allowedRotationAxes; }
         }
 
         /// <summary>
@@ -343,7 +358,7 @@ namespace UnitySteer.Behaviors
                     {
                         // otherwise, test angular offset from forward axis
                         var unitOffset = offset / Mathf.Sqrt(distanceSquared);
-                        var forwardness = Vector3.Dot(Transform.forward, unitOffset);
+                        var forwardness = Vector3.Dot(Forward, unitOffset);
                         result = forwardness > cosMaxAngle;
                     }
                 }
@@ -409,7 +424,7 @@ namespace UnitySteer.Behaviors
         {
             var mf = MaxForce;
             var speedError = targetSpeed - Speed;
-            return Transform.forward * Mathf.Clamp(speedError, -mf, +mf);
+            return Forward * Mathf.Clamp(speedError, -mf, +mf);
         }
 
 
@@ -433,8 +448,8 @@ namespace UnitySteer.Behaviors
         /// </summary>
         public void ResetOrientation()
         {
-            Transform.up = Vector3.up;
-            Transform.forward = Vector3.forward;
+            Transform.up = UpVector;
+            Transform.forward = ForwardVector;
         }
 
         /// <summary>
@@ -503,7 +518,7 @@ namespace UnitySteer.Behaviors
             ref Vector3 hisPosition)
         {
             return ComputeNearestApproachPositions(other, time, ref ourPosition, ref hisPosition, Speed,
-                Transform.forward);
+                Forward );
         }
 
         /// <summary>
@@ -537,7 +552,7 @@ namespace UnitySteer.Behaviors
             Vector3 ourForward)
         {
             var myTravel = ourForward * ourSpeed * time;
-            var otherTravel = other.Transform.forward * other.Speed * time;
+            var otherTravel = other.Forward * other.Speed * time;
 
             ourPosition = Position + myTravel;
             hisPosition = other.Position + otherTravel;


### PR DESCRIPTION
So this allowes me to setup 2D project with forward as Vector3.up and up vector as Vector3.back
With only Z axis allowed for rotation it correctly rotates the sprites.

Without changing these, the behavior should be the same as before changes - just Slerp is done on Quaternion not on the direction vector.

One major thing to still do is have the Up/Forward vectors as global options. Now it's needed to be set on each DetectableObject separately.. ( managable by prefabs I guess )
