### PR TITLE
Small fix for Unity5 support : GetNavMeshLayerFromName to GetAreaFromName

### DIFF
--- a/Behaviors/SteerForNavmesh.cs
+++ b/Behaviors/SteerForNavmesh.cs
@@ -93,7 +93,11 @@ namespace UnitySteer.Behaviors
         protected override void Start()
         {
             base.Start();
+#if UNITY_5
+            _navMeshLayerMask = 1 << NavMesh.GetAreaFromName("Default");
+#else
             _navMeshLayerMask = 1 << NavMesh.GetNavMeshLayerFromName("Default");
+#endif
         }
 
 


### PR DESCRIPTION
Small fix for Unity5 support : GetNavMeshLayerFromName to GetAreaFromName as the former is obsolete in Unity5.