### PR TITLE
Upgrade to Unity 5.5

### DIFF
--- a/2D/Behaviors/Radar2D.cs
+++ b/2D/Behaviors/Radar2D.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using TickedPriorityQueue;
 using UnityEngine;
+using UnityEngine.Profiling;
 using UnitySteer.Attributes;
 
 namespace UnitySteer2D.Behaviors

--- a/2D/Behaviors/SteerForFear2D.cs
+++ b/2D/Behaviors/SteerForFear2D.cs
@@ -1,6 +1,7 @@
 //#define ANNOTATE_REPULSION
 
 using UnityEngine;
+using UnityEngine.Profiling;
 
 namespace UnitySteer2D.Behaviors
 {

--- a/2D/Behaviors/SteerForNeighborGroup2D.cs
+++ b/2D/Behaviors/SteerForNeighborGroup2D.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Profiling;
 using UnitySteer.Attributes;
 
 namespace UnitySteer2D.Behaviors

--- a/2D/Behaviors/SteerForSphericalObstacles2D.cs
+++ b/2D/Behaviors/SteerForSphericalObstacles2D.cs
@@ -2,6 +2,7 @@
 
 using System.Linq;
 using UnityEngine;
+using UnityEngine.Profiling;
 
 namespace UnitySteer2D.Behaviors
 {

--- a/2D/Behaviors/TickedVehicle2D.cs
+++ b/2D/Behaviors/TickedVehicle2D.cs
@@ -3,12 +3,13 @@
 using System.Diagnostics;
 using TickedPriorityQueue;
 using UnityEngine;
+using UnityEngine.Profiling;
 using Debug = UnityEngine.Debug;
 
 namespace UnitySteer2D.Behaviors
 {
     /// <summary>
-    /// Vehicle2D subclass oriented towards autonomous bipeds and vehicles, which 
+    /// Vehicle2D subclass oriented towards autonomous bipeds and vehicles, which
     /// will be ticked automatically to calculate their direction.
     /// </summary>
     public abstract class TickedVehicle2D : Vehicle2D

--- a/3D/Behaviors/Radar.cs
+++ b/3D/Behaviors/Radar.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using TickedPriorityQueue;
 using UnityEngine;
+using UnityEngine.Profiling;
 
 namespace UnitySteer.Behaviors
 {

--- a/3D/Behaviors/SteerForFear.cs
+++ b/3D/Behaviors/SteerForFear.cs
@@ -1,6 +1,7 @@
 //#define ANNOTATE_REPULSION
 
 using UnityEngine;
+using UnityEngine.Profiling;
 
 namespace UnitySteer.Behaviors
 {

--- a/3D/Behaviors/SteerForNavmesh.cs
+++ b/3D/Behaviors/SteerForNavmesh.cs
@@ -1,5 +1,7 @@
 #define ANNOTATE_NAVMESH
 using UnityEngine;
+using UnityEngine.AI;
+using UnityEngine.Profiling;
 
 namespace UnitySteer.Behaviors
 {

--- a/3D/Behaviors/SteerForNeighborGroup.cs
+++ b/3D/Behaviors/SteerForNeighborGroup.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnitySteer.Attributes;
+using UnityEngine.Profiling;
 
 namespace UnitySteer.Behaviors
 {

--- a/3D/Behaviors/SteerForSphericalObstacles.cs
+++ b/3D/Behaviors/SteerForSphericalObstacles.cs
@@ -1,6 +1,7 @@
 #define ANNOTATE_AVOIDOBSTACLES
 using System.Linq;
 using UnityEngine;
+using UnityEngine.Profiling;
 
 namespace UnitySteer.Behaviors
 {

--- a/3D/Behaviors/TickedVehicle.cs
+++ b/3D/Behaviors/TickedVehicle.cs
@@ -2,12 +2,13 @@
 using System.Diagnostics;
 using TickedPriorityQueue;
 using UnityEngine;
+using UnityEngine.Profiling;
 using Debug = UnityEngine.Debug;
 
 namespace UnitySteer.Behaviors
 {
     /// <summary>
-    /// Vehicle subclass oriented towards autonomous bipeds and vehicles, which 
+    /// Vehicle subclass oriented towards autonomous bipeds and vehicles, which
     /// will be ticked automatically to calculate their direction.
     /// </summary>
     public abstract class TickedVehicle : Vehicle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # UnitySteer changelog
 
+## WIP
+
+* Upgrade project to Unity 5.5
+
 ## v3.1
 
 * 2D support thanks to @GandaG and @pjohalloran. 


### PR DESCRIPTION
I've just started trying out UnitySteer: thanks for creating it!

Unity 5.5 moves a few classes around and the auto-upgrade makes a bit of a mess of it, pre-pending the new namespace everywhere which will cause some merge issues down the line; the better solution is just to import the new namespaces, which is what this PR does.

Pretty simple but hope it's useful 😄 