### PR TITLE
Fix SteerForPathSimplified2D still getting stuck on loops

### DIFF
--- a/2D/Behaviors/SteerForPathSimplified2D.cs
+++ b/2D/Behaviors/SteerForPathSimplified2D.cs
@@ -140,7 +140,7 @@ namespace UnitySteer2D.Behaviors
 		 */
             var seek = Vehicle.GetSeekVector(target);
 
-            if (seek == Vector2.zero && targetPathDistance <= Path.TotalPathLength)
+            while (seek == Vector2.zero && targetPathDistance <= Path.TotalPathLength)
             {
                 /*
 			 * If we should not displace but still have some distance to go,
@@ -151,7 +151,8 @@ namespace UnitySteer2D.Behaviors
 			 * radius.  In that case, aim a bit further beyond the vehicle's 
 			 * arrival radius so that it can continue moving.
 			 */
-                target = Path.MapPathDistanceToPoint(targetPathDistance + 2f * Vehicle.ArrivalRadius);
+                targetPathDistance += 2f * Vehicle.ArrivalRadius;
+                target = Path.MapPathDistanceToPoint(targetPathDistance);
                 seek = Vehicle.GetSeekVector(target);
             }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # UnitySteer changelog
 
+## WIP
+
+* SteerForPathSimplified2D can now resolve longer loops instead of getting stuck
+
 ## v3.1
 
 * 2D support thanks to @GandaG and @pjohalloran. 


### PR DESCRIPTION
If resolving a loop means advancing further than 2*Vehicle.ArrivalRadius, the previous code would always stall. This change means that we will always resolve a loop no matter how loopy it is (usually max 2/3 iterations).

I came across this case quite often for some reason and I realised because it only tried to advance once, if that didn't work, it would never resolve it. Making it a while loop works and is guaranteed to exit in edge cases since it's bounded by the path length.