### PR TITLE
Add OnNeighborsChanged event to SteerForNeighborGroup2D

### DIFF
--- a/2D/Behaviors/SteerForNeighborGroup2D.cs
+++ b/2D/Behaviors/SteerForNeighborGroup2D.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Profiling;
 using UnitySteer.Attributes;
 
 namespace UnitySteer2D.Behaviors
@@ -116,6 +118,12 @@ namespace UnitySteer2D.Behaviors
             get { return _neighbors; }
         }
 
+        /// <summary>
+        /// Delegate which is called when the detected neighbors list is changed
+        /// </summary>
+        public Action<SteerForNeighborGroup2D> OnNeighborsChanged = delegate { };
+
+
         #endregion
 
         #region Methods
@@ -162,6 +170,14 @@ namespace UnitySteer2D.Behaviors
                     _neighbors.Add(other);
                 }
             }
+
+            if (OnNeighborsChanged != null)
+            {
+                Profiler.BeginSample("Neighbor event handler");
+                OnNeighborsChanged(this);
+                Profiler.EndSample();
+            }
+
         }
 
         protected override Vector2 CalculateForce()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # UnitySteer changelog
 
+## WIP
+
+* Added OnNeighborsChanged event to SteerForNeighbourGroup2D
+
 ## v3.1
 
 * 2D support thanks to @GandaG and @pjohalloran. 


### PR DESCRIPTION
This is useful for adjusting other behaviours when neighbors change; I found that while aggregation of group behaviours is useful, sometimes you want to be able to change behaviours entirely depending on what's going on with the group, for example if you want to nominate one group leader which changes as groups form & split based on other factors.