### PR TITLE
Add min/max cohesion contribution for more controllable flocking

### DIFF
--- a/2D/Behaviors/SteerForCohesion2D.cs
+++ b/2D/Behaviors/SteerForCohesion2D.cs
@@ -11,14 +11,17 @@ namespace UnitySteer2D.Behaviors
     [RequireComponent(typeof (SteerForNeighborGroup2D))]
     public class SteerForCohesion2D : SteerForNeighbors2D
     {
+        [SerializeField] private float _minContribution = 0f;
+        [SerializeField] private float _maxContribution = 1f;
+
         public override Vector2 CalculateNeighborContribution(Vehicle2D other)
         {
             // accumulate sum of forces leading us towards neighbor's positions
             var distance = other.Position - Vehicle.Position;
             var sqrMag = distance.sqrMagnitude;
-            // Provide some contribution, but diminished by the distance to 
+            // Provide some contribution, but diminished by the distance to
             // the vehicle.
-            distance *= 1 / sqrMag;
+            distance *= Mathf.Clamp(1 / sqrMag, _minContribution, _maxContribution);
             return distance;
         }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # UnitySteer changelog
 
+## WIP
+
+* SteerForCohesion2D now has min/max contribution properties; this can assist
+  flocking by preventing the cohesion factor from becoming too strong/weak with 
+  distance
+
 ## v3.1
 
 * 2D support thanks to @GandaG and @pjohalloran. 


### PR DESCRIPTION
I found adding a min/max limit for the cohesion component helped make flocking behaviour more controllable.

I set mine to 0.2 and 0.5 respectively, which I find helps avoid over-clustering close up (less reliance on separation to balance out) and keeps vague tracking within the group right up to the edge of the neighbour range instead of it falling off before that. Default is 0/1 though which is no change on previous behaviour.