### PR TITLE
PredictFuturePosition now checks for Position

### DIFF
--- a/3D/Behaviors/Vehicle.cs
+++ b/3D/Behaviors/Vehicle.cs
@@ -286,7 +286,7 @@ namespace UnitySteer.Behaviors
         /// </returns>
         public override Vector3 PredictFuturePosition(float predictionTime)
         {
-            return Transform.position + (Velocity * predictionTime);
+            return Position + (Velocity * predictionTime);
         }
 
         /// <summary>
@@ -300,7 +300,7 @@ namespace UnitySteer.Behaviors
         /// </returns>
         public Vector3 PredictFutureDesiredPosition(float predictionTime)
         {
-            return Transform.position + (DesiredVelocity * predictionTime);
+            return Position + (DesiredVelocity * predictionTime);
         }
 
 


### PR DESCRIPTION
Both the PredictFuturePosition and PredictFutureDesiredPosition should check for the Position property instead of the Transform.position property, so as to account for the DetectableObject's Center offset.

The biggest bug I've found regarding the previous implementation is in regards to the SteerForSphericalObstacles script, which uses the return value of PredictFutureDesiredPosition() to construct a movement vector to work with. This movement vector will be inaccurate since in the steering behaviors I've seen, the DesiredVelocity is being applied with the vehicle's Center property in mind (e.g. SteerForPathSimplified). That is, DesiredVelocity goes from detectableObject.Position to a future detectableObject.Position, but the constructed movement vectory in SteerForSphericalObstacles was going from dectectableObect.Position to a future transform.Position, an inaccurate move vector resulting in inaccurate collision checks.

However, I haven't fully explored all calls to the PredictFuturePosition() functions, so it might create problems somewhere...