### PR TITLE
Fixed a bug that would incorrectly calculate the intersection points in SteerForSphericalObstacles

### DIFF
--- a/2D/Behaviors/SteerForSphericalObstacles2D.cs
+++ b/2D/Behaviors/SteerForSphericalObstacles2D.cs
@@ -198,7 +198,7 @@ namespace UnitySteer2D.Behaviors
             }
 
             // use pythagorean theorem to calculate distance out of the sphere (if you do it 2D, the line through the circle would be a chord and we need half of its length)
-            var halfChord = Mathf.Sqrt(combinedRadius * combinedRadius + obstacleDistanceToPath * obstacleDistanceToPath);
+            var halfChord = Mathf.Sqrt(combinedRadius * combinedRadius - obstacleDistanceToPath * obstacleDistanceToPath);
 
             // if the projected obstacle center lies opposite to the movement direction (aka "behind")
             if (projectionLength < 0)

--- a/3D/Behaviors/SteerForSphericalObstacles.cs
+++ b/3D/Behaviors/SteerForSphericalObstacles.cs
@@ -197,7 +197,7 @@ namespace UnitySteer.Behaviors
             }
 
             // use pythagorean theorem to calculate distance out of the sphere (if you do it 2D, the line through the circle would be a chord and we need half of its length)
-            var halfChord = Mathf.Sqrt(combinedRadius * combinedRadius + obstacleDistanceToPath * obstacleDistanceToPath);
+            var halfChord = Mathf.Sqrt(combinedRadius * combinedRadius - obstacleDistanceToPath * obstacleDistanceToPath);
 
             // if the projected obstacle center lies opposite to the movement direction (aka "behind")
             if (projectionLength < 0)


### PR DESCRIPTION
I believe the Pythagorean theorem code should have a subtraction, not an addition. While debug rendering the calculated intersection points, the original code could generate points that were wildly off. Changing the formula now generates the intersection points directly on the radius of the sphere/circle.

This might not have much impact on obstacle avoidance (the original points would indeed steer the vehicle away from the obstacle) but it should allow the vehicles to have a closer tolerance to the obstacle.