### PR TITLE
Compatibility with Unity 2017

### DIFF
--- a/3D/Behaviors/SteerForNavmesh.cs
+++ b/3D/Behaviors/SteerForNavmesh.cs
@@ -93,8 +93,10 @@ namespace UnitySteer.Behaviors
         protected override void Start()
         {
             base.Start();
-#if UNITY_5
-            _navMeshLayerMask = 1 << NavMesh.GetAreaFromName("Default");
+#if UNITY_2017_1_OR_NEWER
+			_navMeshLayerMask = 1 << NavMesh.GetAreaFromName("Walkable");
+#elif UNITY_5
+			_navMeshLayerMask = 1 << NavMesh.GetAreaFromName("Default");
 #else
             _navMeshLayerMask = 1 << NavMesh.GetNavMeshLayerFromName("Default");
 #endif


### PR DESCRIPTION
- added if UNITY_2017_1_OR_NEWER directive
- default navmesh area in 2017 is "Walkable"